### PR TITLE
Add bench chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,53 +46,54 @@ Browse with full per-chart documentation on the site: <https://geekxflood.github
 
 <!-- charts:start -->
 
-| Chart                                               | Version | App Version | Description                                                                                                                       |
-| --------------------------------------------------- | ------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [audiobookshelf](charts/audiobookshelf)             | 0.6.0   | latest      | Audiobookshelf - Self-hosted audiobook and podcast server                                                                         |
-| [backuparr](charts/backuparr)                       | 1.2.1   | 1.2.0       | Automated backup solution for *arr applications using their native APIs                                                           |
-| [bazarr](charts/bazarr)                             | 0.6.0   | 1.5.2       | Bazarr - Subtitle management for Sonarr and Radarr                                                                                |
-| [cleanuparr](charts/cleanuparr)                     | 0.2.0   | 1.0.0       | A Helm chart for deploying Cleanuparr - Media library cleanup tool                                                                |
-| [database-provisioner](charts/database-provisioner) | 1.0.0   | 1.0         | Automated database provisioner for CloudNativePG Database CRDs                                                                    |
-| [dizquetv](charts/dizquetv)                         | 0.2.1   | 1.7.0       | A Helm chart for Kubernetes for deploying DizqueTV                                                                                |
-| [ersatztv](charts/ersatztv)                         | 1.2.0   | v25.2.0     | A Helm chart for ErsatzTV - custom live TV channels using your media library                                                      |
-| [flaresolverr](charts/flaresolverr)                 | 0.3.0   | v3.4.6      | A Helm chart for Kubernetes for deploying Flaresolverr                                                                            |
-| [garage](charts/garage)                             | 1.1.1   | v2.3.0      | S3-compatible object store for small self-hosted geo-distributed deployments                                                      |
-| [huntarr](charts/huntarr)                           | 0.2.0   | 1.0.0       | A Helm chart for deploying Huntarr - Automated missing media finder for *arr apps                                                 |
-| [jellyfin](charts/jellyfin)                         | 0.11.1  | 10.11.8     | A Helm chart for Kubernetes for deploying Jellyfin Media Server                                                                   |
-| [kapowarr](charts/kapowarr)                         | 0.2.0   | 1.0.0       | A Helm chart for deploying Kapowarr - Comic book library manager                                                                  |
-| [keycloak](charts/keycloak)                         | 0.12.1  | 26.6.1      | A Helm chart for Keycloak - Open Source Identity and Access Management                                                            |
-| [lazylibrarian](charts/lazylibrarian)               | 0.2.0   | latest      | LazyLibrarian - Automated ebook and audiobook manager                                                                             |
-| [lingarr](charts/lingarr)                           | 0.2.0   | 1.0.0       | A Helm chart for deploying Lingarr - Automatic subtitle translator                                                                |
-| [mkdocs-material](charts/mkdocs-material)           | 1.1.1   | 9.7.6       | MkDocs Material theme documentation site with git-sync for auto-updates                                                           |
-| [oauth2-proxy](charts/oauth2-proxy)                 | 1.0.2   | 7.15.2      | OAuth2 Proxy for authenticating applications via Keycloak OIDC                                                                    |
-| [ollama](charts/ollama)                             | 1.0.0   | 0.4.6       | Ollama - Run large language models locally with GPU support                                                                       |
-| [open-webui](charts/open-webui)                     | 1.1.0   | 0.4.8       | Open WebUI - User-friendly web interface for LLMs like Ollama                                                                     |
-| [openbao-unsealer](charts/openbao-unsealer)         | 1.0.0   | 2.3.1       | Automated unsealing for OpenBao cluster using unseal keys from Kubernetes secret                                                  |
-| [openwatchparty](charts/openwatchparty)             | 0.2.0   | latest      | OpenWatchParty - Synchronized media playback for Jellyfin watch parties                                                           |
-| [overseer](charts/overseer)                         | 0.4.0   | 1.33.2      | A Helm chart for Kubernetes                                                                                                       |
-| [overseerr](charts/overseerr)                       | 0.3.1   | 1.35.0      | A Helm chart for Kubernetes for deploying Overseerr                                                                               |
-| [plex](charts/plex)                                 | 0.5.0   | 1.42.2      | A Helm chart for deploying Plex Media Server on Kubernetes                                                                        |
-| [posterizarr](charts/posterizarr)                   | 0.2.0   | latest      | Automated poster generation for media libraries with Web UI support for Plex, Jellyfin, and Emby                                  |
-| [postgres-ha](charts/postgres-ha)                   | 1.0.0   | 16          | High-availability PostgreSQL cluster using CloudNativePG                                                                          |
-| [program-director](charts/program-director)         | 1.2.0   | 1.1.1       | AI-powered TV channel programmer for Tunarr                                                                                       |
-| [prowlarr](charts/prowlarr)                         | 1.1.0   | 2.0.5       | A Helm chart for Kubernetes                                                                                                       |
-| [radarr](charts/radarr)                             | 0.5.0   | 5.23.1      | A Helm chart for deploying Radarr on Kubernetes                                                                                   |
-| [readarr](charts/readarr)                           | 0.2.0   | 0.4.4.2686  | A Helm chart for deploying Readarr on Kubernetes                                                                                  |
-| [rreading-glasses](charts/rreading-glasses)         | 0.2.0   | latest      | Metadata service for book and audiobook management applications                                                                   |
-| [sabnzbd](charts/sabnzbd)                           | 0.2.0   | latest      | A Helm chart for SABnzbd - Usenet Downloader                                                                                      |
-| [seerr](charts/seerr)                               | 1.1.0   | develop     | Open-source media request and discovery manager for Jellyfin, Plex, and Emby                                                      |
-| [sonarr](charts/sonarr)                             | 0.5.0   | 4.0.16      | A Helm chart for deploying Sonarr on Kubernetes                                                                                   |
-| [subgen](charts/subgen)                             | 1.0.0   | 2024.12.1   | SubGen - Autogenerate subtitles using OpenAI Whisper Model                                                                        |
-| [tautulli-exporter](charts/tautulli-exporter)       | 0.2.0   | v0.1.0      | A Helm chart for Kubernetes for deploying Tautulli-exporter                                                                       |
-| [tautulli](charts/tautulli)                         | 0.3.1   | 2.17.1      | A Helm chart for Kubernetes for deploying Tautulli                                                                                |
-| [tdarr](charts/tdarr)                               | 1.4.1   | 2.73.01     | Tdarr Helm chart for Kubernetes - Distributed transcode system for automating media library transcode/remux management            |
-| [tdarr-node](charts/tdarr_node)                     | 0.6.1   | 2.73.01     | A Helm chart for Kubernetes for deploying tdarr transcoding nodes                                                                 |
-| [tdarr-server](charts/tdarr_server)                 | 0.5.1   | 2.73.01     | A Helm chart for Kubernetes for deploying tdarr server                                                                            |
-| [transmission-openvpn](charts/transmission-openvpn) | 0.2.1   | 5.4.1       | A Helm chart for Kubernetes for deploying Transmission                                                                            |
-| [tunarr](charts/tunarr)                             | 0.5.0   | 1.2.17      | A Helm chart for Tunarr - Create live TV channels from media on your Plex/Jellyfin/Emby servers with built-in HDHomeRun emulation |
-| [unmanic](charts/unmanic)                           | 0.3.1   | 0.4.0       | A Helm chart for Kubernetes for deploying Unmanic                                                                                 |
-| [whisper](charts/whisper)                           | 1.3.0   | 1.6.1-gpu   | OpenAI Whisper ASR Webservice for automatic speech recognition and subtitle generation with Bazarr                                |
-| [wizarr](charts/wizarr)                             | 0.2.1   | 2026.4.0    | A Helm chart for deploying Wizarr - automatic user invitation and management system for media servers                             |
+| Chart | Version | App Version | Description |
+|---|---|---|---|
+| [audiobookshelf](charts/audiobookshelf) | 0.6.0 | latest | Audiobookshelf - Self-hosted audiobook and podcast server |
+| [backuparr](charts/backuparr) | 1.2.1 | 1.2.0 | Automated backup solution for *arr applications using their native APIs |
+| [bazarr](charts/bazarr) | 0.6.0 | 1.5.2 | Bazarr - Subtitle management for Sonarr and Radarr |
+| [bench](charts/bench) | 0.1.0 | latest | A Helm chart for deploying bench — a static WoW raid bench roller |
+| [cleanuparr](charts/cleanuparr) | 0.2.0 | 1.0.0 | A Helm chart for deploying Cleanuparr - Media library cleanup tool |
+| [database-provisioner](charts/database-provisioner) | 1.0.0 | 1.0 | Automated database provisioner for CloudNativePG Database CRDs |
+| [dizquetv](charts/dizquetv) | 0.2.1 | 1.7.0 | A Helm chart for Kubernetes for deploying DizqueTV |
+| [ersatztv](charts/ersatztv) | 1.2.0 | v25.2.0 | A Helm chart for ErsatzTV - custom live TV channels using your media library |
+| [flaresolverr](charts/flaresolverr) | 0.3.0 | v3.4.6 | A Helm chart for Kubernetes for deploying Flaresolverr |
+| [garage](charts/garage) | 1.1.1 | v2.3.0 | S3-compatible object store for small self-hosted geo-distributed deployments |
+| [huntarr](charts/huntarr) | 0.2.0 | 1.0.0 | A Helm chart for deploying Huntarr - Automated missing media finder for *arr apps |
+| [jellyfin](charts/jellyfin) | 0.11.1 | 10.11.8 | A Helm chart for Kubernetes for deploying Jellyfin Media Server |
+| [kapowarr](charts/kapowarr) | 0.2.0 | 1.0.0 | A Helm chart for deploying Kapowarr - Comic book library manager |
+| [keycloak](charts/keycloak) | 0.12.1 | 26.6.1 | A Helm chart for Keycloak - Open Source Identity and Access Management |
+| [lazylibrarian](charts/lazylibrarian) | 0.2.0 | latest | LazyLibrarian - Automated ebook and audiobook manager |
+| [lingarr](charts/lingarr) | 0.2.0 | 1.0.0 | A Helm chart for deploying Lingarr - Automatic subtitle translator |
+| [mkdocs-material](charts/mkdocs-material) | 1.1.1 | 9.7.6 | MkDocs Material theme documentation site with git-sync for auto-updates |
+| [oauth2-proxy](charts/oauth2-proxy) | 1.0.2 | 7.15.2 | OAuth2 Proxy for authenticating applications via Keycloak OIDC |
+| [ollama](charts/ollama) | 1.0.0 | 0.4.6 | Ollama - Run large language models locally with GPU support |
+| [open-webui](charts/open-webui) | 1.1.0 | 0.4.8 | Open WebUI - User-friendly web interface for LLMs like Ollama |
+| [openbao-unsealer](charts/openbao-unsealer) | 1.0.0 | 2.3.1 | Automated unsealing for OpenBao cluster using unseal keys from Kubernetes secret |
+| [openwatchparty](charts/openwatchparty) | 0.2.0 | latest | OpenWatchParty - Synchronized media playback for Jellyfin watch parties |
+| [overseer](charts/overseer) | 0.4.0 | 1.33.2 | A Helm chart for Kubernetes |
+| [overseerr](charts/overseerr) | 0.3.1 | 1.35.0 | A Helm chart for Kubernetes for deploying Overseerr |
+| [plex](charts/plex) | 0.5.0 | 1.42.2 | A Helm chart for deploying Plex Media Server on Kubernetes |
+| [posterizarr](charts/posterizarr) | 0.2.0 | latest | Automated poster generation for media libraries with Web UI support for Plex, Jellyfin, and Emby |
+| [postgres-ha](charts/postgres-ha) | 1.0.0 | 16 | High-availability PostgreSQL cluster using CloudNativePG |
+| [program-director](charts/program-director) | 1.2.0 | 1.1.1 | AI-powered TV channel programmer for Tunarr |
+| [prowlarr](charts/prowlarr) | 1.1.0 | 2.0.5 | A Helm chart for Kubernetes |
+| [radarr](charts/radarr) | 0.5.0 | 5.23.1 | A Helm chart for deploying Radarr on Kubernetes |
+| [readarr](charts/readarr) | 0.2.0 | 0.4.4.2686 | A Helm chart for deploying Readarr on Kubernetes |
+| [rreading-glasses](charts/rreading-glasses) | 0.2.0 | latest | Metadata service for book and audiobook management applications |
+| [sabnzbd](charts/sabnzbd) | 0.2.0 | latest | A Helm chart for SABnzbd - Usenet Downloader |
+| [seerr](charts/seerr) | 1.1.0 | develop | Open-source media request and discovery manager for Jellyfin, Plex, and Emby |
+| [sonarr](charts/sonarr) | 0.5.0 | 4.0.16 | A Helm chart for deploying Sonarr on Kubernetes |
+| [subgen](charts/subgen) | 1.0.0 | 2024.12.1 | SubGen - Autogenerate subtitles using OpenAI Whisper Model |
+| [tautulli-exporter](charts/tautulli-exporter) | 0.2.0 | v0.1.0 | A Helm chart for Kubernetes for deploying Tautulli-exporter |
+| [tautulli](charts/tautulli) | 0.3.1 | 2.17.1 | A Helm chart for Kubernetes for deploying Tautulli |
+| [tdarr](charts/tdarr) | 1.4.1 | 2.73.01 | Tdarr Helm chart for Kubernetes - Distributed transcode system for automating media library transcode/remux management |
+| [tdarr-node](charts/tdarr_node) | 0.6.1 | 2.73.01 | A Helm chart for Kubernetes for deploying tdarr transcoding nodes |
+| [tdarr-server](charts/tdarr_server) | 0.5.1 | 2.73.01 | A Helm chart for Kubernetes for deploying tdarr server |
+| [transmission-openvpn](charts/transmission-openvpn) | 0.2.1 | 5.4.1 | A Helm chart for Kubernetes for deploying Transmission |
+| [tunarr](charts/tunarr) | 0.5.0 | 1.2.17 | A Helm chart for Tunarr - Create live TV channels from media on your Plex/Jellyfin/Emby servers with built-in HDHomeRun emulation |
+| [unmanic](charts/unmanic) | 0.3.1 | 0.4.0 | A Helm chart for Kubernetes for deploying Unmanic |
+| [whisper](charts/whisper) | 1.3.0 | 1.6.1-gpu | OpenAI Whisper ASR Webservice for automatic speech recognition and subtitle generation with Bazarr |
+| [wizarr](charts/wizarr) | 0.2.1 | 2026.4.0 | A Helm chart for deploying Wizarr - automatic user invitation and management system for media servers |
 
 <!-- charts:end -->
 

--- a/charts/bench/Chart.yaml
+++ b/charts/bench/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: bench
+description: A Helm chart for deploying bench — a static WoW raid bench roller
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://bench.geekxflood.io
+sources:
+  - https://github.com/geekxflood/bench
+maintainers:
+  - name: geekxflood
+    url: https://github.com/geekxflood

--- a/charts/bench/README.md
+++ b/charts/bench/README.md
@@ -1,0 +1,87 @@
+# bench Helm Chart
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+
+A Helm chart for deploying [bench](https://github.com/geekxflood/bench) on Kubernetes. bench is a tiny, static **WoW raid bench roller**: enter your raiders, pick how many to bench, and a d20 roll decides who sits out — then copy the result straight into Discord.
+
+The app is entirely client-side and is served by an unprivileged `nginx` container (`ghcr.io/geekxflood/bench`) listening on port `8080`. It is stateless, has no config, and stores nothing.
+
+## Features
+
+- Stateless deployment of the static site with configurable replicas, resources, probes, and pod metadata.
+- HTTP service on port 8080 with a `/healthz` endpoint wired to liveness/readiness probes.
+- Optional `Ingress`.
+- Optional Gateway API `HTTPRoute` (used here with the Cilium Gateway for `bench.local.geekxflood.io`).
+- Optional Cloudflare Tunnel `TunnelBinding` (used here for the public `bench.geekxflood.io`).
+- HPA template for horizontal scaling.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+
+bench does **not** require persistent storage.
+
+## Installation
+
+### Add the Helm repository
+
+```bash
+helm repo add geekxflood https://geekxflood.github.io/helm-charts
+helm repo update
+```
+
+### Install the chart
+
+```bash
+helm install bench geekxflood/bench --set enabled=true
+```
+
+## Public exposure (geekxflood cluster)
+
+```yaml
+enabled: true
+
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: cilium-gateway
+      namespace: kube-system
+      sectionName: https
+  hostnames:
+    - bench.local.geekxflood.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - {}
+
+cfTunnel:
+  enabled: true
+  tunnelRef:
+    name: gxf-cluster-tunnel
+    kind: ClusterTunnel
+  subjects:
+    - name: bench
+      spec:
+        spec:
+          fqdn: bench.geekxflood.io
+          protocol: http
+```
+
+## Values
+
+| Key | Default | Description |
+|---|---|---|
+| `image.repository` | `ghcr.io/geekxflood/bench` | Container image. |
+| `image.tag` | `""` (chart `appVersion`) | Image tag. |
+| `replicaCount` | `1` | Number of replicas. |
+| `service.port` | `8080` | Service / container port. |
+| `httpRoute.enabled` | `false` | Enable a Gateway API `HTTPRoute`. |
+| `cfTunnel.enabled` | `false` | Enable a Cloudflare `TunnelBinding`. |
+| `ingress.enabled` | `false` | Enable a legacy `Ingress`. |
+| `autoscaling.enabled` | `false` | Enable an HPA. |

--- a/charts/bench/assets/icon.svg
+++ b/charts/bench/assets/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect x="6" y="6" width="52" height="52" rx="14" fill="#171b27" stroke="#2a3142" stroke-width="2"/>
+  <text x="32" y="44" font-family="Georgia, 'Times New Roman', serif" font-size="30" font-weight="700"
+        text-anchor="middle" fill="#f8b700">20</text>
+</svg>

--- a/charts/bench/templates/NOTES.txt
+++ b/charts/bench/templates/NOTES.txt
@@ -1,0 +1,20 @@
+bench has been deployed. 🎲
+
+{{- if .Values.cfTunnel.enabled }}
+{{- range .Values.cfTunnel.subjects }}
+{{- if .spec }}
+Public URL (Cloudflare Tunnel): https://{{ .spec.spec.fqdn }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.httpRoute.enabled }}
+{{- range .Values.httpRoute.hostnames }}
+Internal URL (Gateway):         https://{{ . }}
+{{- end }}
+{{- end }}
+{{- if not (or .Values.cfTunnel.enabled .Values.httpRoute.enabled .Values.ingress.enabled) }}
+No external route is enabled. Port-forward to try it:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "bench.fullname" . }} 8080:{{ .Values.service.port }}
+  # then open http://localhost:8080
+{{- end }}

--- a/charts/bench/templates/_helpers.tpl
+++ b/charts/bench/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bench.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bench.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bench.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bench.labels" -}}
+helm.sh/chart: {{ include "bench.chart" . }}
+{{ include "bench.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bench.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bench.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bench.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bench.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/bench/templates/deployment.yaml
+++ b/charts/bench/templates/deployment.yaml
@@ -1,0 +1,96 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bench.fullname" . }}
+  labels:
+    {{- include "bench.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "bench.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "bench.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "bench.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.env }}
+          env:
+            {{- range . }}
+            - name: {{ .name | quote }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- range . }}
+            {{- if eq .type "secret" }}
+            - secretRef:
+                name: {{ .name | quote }}
+            {{- end }}
+            {{- if eq .type "configmap" }}
+            - configMapRef:
+                name: {{ .name | quote }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/bench/templates/hpa.yaml
+++ b/charts/bench/templates/hpa.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bench.fullname" . }}
+  labels:
+    {{- include "bench.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bench.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/bench/templates/httproute.yaml
+++ b/charts/bench/templates/httproute.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "bench.fullname" . }}
+  labels:
+    {{- include "bench.labels" . | nindent 4 }}
+    app.kubernetes.io/component: httproute
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- range . }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+      {{- with .kind }}
+      kind: {{ . }}
+      {{- end }}
+      {{- with .group }}
+      group: {{ . }}
+      {{- end }}
+      {{- with .port }}
+      port: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.httpRoute.rules }}
+  rules:
+    {{- range . }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .backendRefs }}
+      backendRefs:
+        {{- range . }}
+        - name: {{ .name | default (include "bench.fullname" $) }}
+          port: {{ .port | default $.Values.service.port }}
+          {{- if hasKey . "weight" }}
+          weight: {{ .weight }}
+          {{- end }}
+          {{- with .namespace }}
+          namespace: {{ . }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/bench/templates/ingress.yaml
+++ b/charts/bench/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "bench.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "bench.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- range . }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/bench/templates/service.yaml
+++ b/charts/bench/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bench.fullname" . }}
+  labels:
+    {{- include "bench.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "bench.selectorLabels" . | nindent 4 }}

--- a/charts/bench/templates/serviceaccount.yaml
+++ b/charts/bench/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bench.serviceAccountName" . }}
+  labels:
+    {{- include "bench.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/bench/templates/tunnelbinding.yaml
+++ b/charts/bench/templates/tunnelbinding.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.cfTunnel.enabled }}
+---
+apiVersion: networking.cfargotunnel.com/v1alpha1
+kind: TunnelBinding
+metadata:
+  name: {{ include "bench.fullname" . }}
+  labels:
+    {{- include "bench.labels" . | nindent 4 }}
+{{- if .Values.cfTunnel.subjects }}
+subjects:
+  {{- range .Values.cfTunnel.subjects }}
+  {{- if .name }}
+  - name: {{ .name }}
+    {{- if .spec }}
+    {{- .spec | toYaml | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- else }}
+subjects:
+  - name: {{ include "bench.fullname" . }}
+{{- end }}
+tunnelRef:
+  {{- .Values.cfTunnel.tunnelRef | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/bench/values.yaml
+++ b/charts/bench/values.yaml
@@ -1,0 +1,114 @@
+---
+enabled: false
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/geekxflood/bench
+  pullPolicy: IfNotPresent
+  # Defaults to the chart appVersion ("latest") when empty.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+# nginx-unprivileged runs as uid 101; just enforce non-root.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  fsGroup: 101
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+env: []
+envFrom: []
+
+service:
+  type: ClusterIP
+  port: 8080
+
+# Static site — probe the nginx /healthz endpoint.
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 20
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 3
+  periodSeconds: 10
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: bench.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+# Gateway API HTTPRoute (Cilium Gateway, TLS at the listener).
+# Cilium notes: parentRefs[*].port is ignored — use sectionName to target a listener.
+httpRoute:
+  enabled: false
+  annotations: {}
+  labels: {}
+  parentRefs: []
+    # - name: cilium-gateway
+    #   namespace: kube-system
+    #   sectionName: https
+  hostnames: []
+    # - bench.local.geekxflood.io
+  rules: []
+    # - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
+    #   backendRefs:
+    #     - {}
+
+# Cloudflare Tunnel (cloudflare-operator TunnelBinding) for public exposure.
+cfTunnel:
+  enabled: false
+  tunnelRef: {}
+  subjects: {}
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 24Mi
+  limits:
+    cpu: 100m
+    memory: 64Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+volumes: []
+volumeMounts: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
Helm chart for **bench** — the static WoW raid bench roller (`ghcr.io/geekxflood/bench`).

## Highlights
- Stateless nginx deployment on `:8080` with `/healthz` liveness/readiness probes.
- Optional Gateway API `HTTPRoute` (Cilium Gateway) and `Ingress`.
- Optional Cloudflare `TunnelBinding` template (disabled by default, consistent with sibling charts).
- `HPA` template; resource requests/limits tuned tiny (static site).
- Follows existing chart conventions (`_helpers.tpl`, labels, README badges).

## Verified
- `helm lint charts/bench` — passes.
- `helm template` with production values renders valid YAML (checked with `yaml.safe_load_all`); HTTPRoute → `bench.local.geekxflood.io`, probes on `/healthz`, image `ghcr.io/geekxflood/bench:latest`.

Root README chart table regenerated via `scripts/update-readme.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)