### PR TITLE
bench: repoint default image to ghcr.io/christopherime/bench

### DIFF
--- a/charts/bench/Chart.yaml
+++ b/charts/bench/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 appVersion: "latest"
 home: https://bench.geekxflood.io
 sources:
-  - https://github.com/geekxflood/bench
+  - https://github.com/christopherime/bench
 maintainers:
   - name: geekxflood
     url: https://github.com/geekxflood

--- a/charts/bench/README.md
+++ b/charts/bench/README.md
@@ -4,9 +4,9 @@
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
-A Helm chart for deploying [bench](https://github.com/geekxflood/bench) on Kubernetes. bench is a tiny, static **WoW raid bench roller**: enter your raiders, pick how many to bench, and a d20 roll decides who sits out — then copy the result straight into Discord.
+A Helm chart for deploying [bench](https://github.com/christopherime/bench) on Kubernetes. bench is a tiny, static **WoW raid bench roller**: enter your raiders, pick how many to bench, and a d20 roll decides who sits out — then copy the result straight into Discord.
 
-The app is entirely client-side and is served by an unprivileged `nginx` container (`ghcr.io/geekxflood/bench`) listening on port `8080`. It is stateless, has no config, and stores nothing.
+The app is entirely client-side and is served by an unprivileged `nginx` container (`ghcr.io/christopherime/bench`) listening on port `8080`. It is stateless, has no config, and stores nothing.
 
 ## Features
 
@@ -77,7 +77,7 @@ cfTunnel:
 
 | Key | Default | Description |
 |---|---|---|
-| `image.repository` | `ghcr.io/geekxflood/bench` | Container image. |
+| `image.repository` | `ghcr.io/christopherime/bench` | Container image. |
 | `image.tag` | `""` (chart `appVersion`) | Image tag. |
 | `replicaCount` | `1` | Number of replicas. |
 | `service.port` | `8080` | Service / container port. |

--- a/charts/bench/values.yaml
+++ b/charts/bench/values.yaml
@@ -4,7 +4,7 @@ enabled: false
 replicaCount: 1
 
 image:
-  repository: ghcr.io/geekxflood/bench
+  repository: ghcr.io/christopherime/bench
   pullPolicy: IfNotPresent
   # Defaults to the chart appVersion ("latest") when empty.
   tag: ""


### PR DESCRIPTION
Follow-up to the bench chart: the app repo moved to the personal **christopherime** account (org Actions are suspended), so the image now publishes to `ghcr.io/christopherime/bench`. Updates the chart's default `image.repository` and the source links in `Chart.yaml`/`README.md`.

Unchanged: the public site URL `bench.geekxflood.io` and the `helm install geekxflood/bench` repo alias.

`helm lint charts/bench` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)